### PR TITLE
Test improvements

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,7 +4,7 @@ import { RequestBodyInterceptor, ResponseBodyInterceptor } from '../routes/types
 export type Config = {
   validateResources: boolean
   resources: string[]
-  apiPrefix: string
+  apiPrefix: string | null
   cacheControl: string
   requestBodyInterceptor: RequestBodyInterceptor
   responseBodyInterceptor: ResponseBodyInterceptor
@@ -49,7 +49,7 @@ const defaultConfig: Config = {
   resources: [],
   validateResources: false,
   staticFolder: null,
-  apiPrefix: '',
+  apiPrefix: null,
   connectionString: null,
   cacheControl: 'no-store',
   delay: 0,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,14 +8,16 @@ export type Config = {
   cacheControl: string
   requestBodyInterceptor: RequestBodyInterceptor
   responseBodyInterceptor: ResponseBodyInterceptor
-  staticFolder: string
-  connectionString: string
+  staticFolder: string | null
+  connectionString: string | null
   delay: number
-  customRouter: Router
+  customRouter: Router | null
   returnNullFields: boolean
   isTesting: boolean
   port: number
 }
+
+export type ConfigKey = keyof Config
 
 export type RouterConfig = Pick<
   Config,
@@ -71,7 +73,7 @@ const defaultConfig: Config = {
   port: 3000,
 }
 
-export function initConfig(userConfig: UserConfig): Config {
+export function initConfig(userConfig?: UserConfig): Config {
   if (!userConfig) return defaultConfig
 
   const config = { ...defaultConfig } as Config
@@ -102,7 +104,7 @@ export function initConfig(userConfig: UserConfig): Config {
     userConfig.delay !== 0 &&
     typeof Number(userConfig.delay) === 'number' &&
     Number(userConfig.delay) > 0 &&
-    Number(userConfig.delay) < 10000
+    Number(userConfig.delay) < 100000
   ) {
     config.delay = Number(userConfig.delay)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ function createServer(userConfig?: UserConfig) {
     app.use(express.static(config.staticFolder))
   }
 
-  // On the root URL (with apiPrefix if applicable) only a GET is allowed.
+  // On the root URL (with apiPrefix, if applicable) only a GET is allowed.
   const rootPath = config.apiPrefix ? `${config.apiPrefix}` : '/'
   app.use(rootPath, rootRouter)
 
@@ -43,18 +43,21 @@ function createServer(userConfig?: UserConfig) {
     app.use(config.customRouter)
   }
 
-  // For all other URLs, only GET, POST, PUT and DELETE are allowed and handled.
-  const resourceRouter = createResourceRouter(queries, config)
+  // Temba supports the GET, POST, PUT, PATCH, DELETE, and HEAD methods for resource URLs.
+  // HEAD is not implemented here, because Express supports it out of the box.
+
+  // Create a router on all other URLs, for all supported methods
   const resourcePath = config.apiPrefix ? `${config.apiPrefix}*` : '*'
+  const resourceRouter = createResourceRouter(queries, config)
   app.use(resourcePath, resourceRouter)
 
-  // In case of an API prefix, GET, POST, PUT and DELETE requests to all other URLs return a 404 Not Found.
-  //TODO Hier missen toch HTTP methods?
+  // In case of an API prefix, resource URLs outside of the API prefix return a 404 Not Found.
   if (config.apiPrefix) {
     app.get('*', handleNotFound)
     app.post('*', handleNotFound)
     app.put('*', handleNotFound)
     app.delete('*', handleNotFound)
+    app.patch('*', handleNotFound)
   }
 
   // All other methods to any URL are not allowed.

--- a/src/routes/get.ts
+++ b/src/routes/get.ts
@@ -1,7 +1,7 @@
 import { removeNullFields } from './utils'
 
 function createGetRoutes(queries, cacheControl, responseBodyInterceptor, returnNullFields) {
-  async function handleGetResource(req, res) {
+  async function handleGet(req, res) {
     try {
       const { resource, id } = req.requestInfo
 
@@ -55,7 +55,7 @@ function createGetRoutes(queries, cacheControl, responseBodyInterceptor, returnN
   }
 
   return {
-    handleGetResource,
+    handleGet,
   }
 }
 

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -19,7 +19,7 @@ function createResourceRouter(queries, routerConfig: RouterConfig) {
     returnNullFields,
   } = routerConfig
 
-  const { handleGetResource } = createGetRoutes(
+  const { handleGet } = createGetRoutes(
     queries,
     cacheControl,
     responseBodyInterceptor,
@@ -37,7 +37,7 @@ function createResourceRouter(queries, routerConfig: RouterConfig) {
 
   resourceRouter
     // The router.get() function automatically handles HEAD requests as well, unless router.head is called first.
-    .get('*', getResourceAndId, validateResource, handleGetResource)
+    .get('*', getResourceAndId, validateResource, handleGet)
     .post('*', getResourceAndId, validateResource, handlePost)
     .put('*', getResourceAndId, validateResource, handlePut)
     .patch('*', getResourceAndId, validateResource, handlePatch)

--- a/test/integration/api-prefix-config.test.ts
+++ b/test/integration/api-prefix-config.test.ts
@@ -24,16 +24,29 @@ test('GET on apiPrefix URL returns welcome text', async () => {
   expect(response.text).toEqual('It works! ツ')
 })
 
-test('GET on resource URL without apiPrefix returns 404 Not Found error', async () => {
-  const response = await request(tembaServer).get('/movies')
-
-  expect(response.statusCode).toEqual(404)
-  expect(response.body.message).toEqual('Not Found')
-})
-
 test('GET on apiPrefix and resource URL returns empty array', async () => {
-  const response = await request(tembaServer).get('/' + apiPrefix + '/movies')
+  const movies = '/' + apiPrefix + '/movies/'
 
-  expect(response.statusCode).toEqual(200)
-  expect(response.text).toEqual('[]')
+  expect((await request(tembaServer).get(movies)).statusCode).toEqual(200)
+
+  const post = await request(tembaServer).post(movies)
+  expect(post.statusCode).toEqual(201)
+
+  const movie = movies + post.body.id
+
+  expect((await request(tembaServer).get(movie)).statusCode).toEqual(200)
+
+  expect((await request(tembaServer).put(movie)).statusCode).toEqual(200)
+
+  expect((await request(tembaServer).patch(movie)).statusCode).toEqual(200)
+
+  expect((await request(tembaServer).delete(movie)).statusCode).toEqual(204)
 })
+
+test.each(['get', 'post', 'put', 'delete', 'patch', 'head'])(
+  '%s on resource URL without apiPrefix returns 404 Not Found error',
+  async (method) => {
+    const response = await request(tembaServer)[method]('/movies')
+    expect(response.statusCode).toEqual(404)
+  },
+)

--- a/test/integration/requestBodyInterceptor/requestBodyInterceptor-change-requestBody.test.ts
+++ b/test/integration/requestBodyInterceptor/requestBodyInterceptor-change-requestBody.test.ts
@@ -2,17 +2,16 @@ import request from 'supertest'
 import { Config } from '../../../src/config'
 import createServer from '../createServer'
 
-//TODO add patch
-
 describe('requestBodyInterceptors that return a (new or changed) request body', () => {
   const requestBodyInterceptor = {
     post: ({ resource }) => {
-      expect(['movies', 'pokemons']).toContain(resource)
       if (resource === 'movies') return { title: 'The Matrix' }
     },
-    put: ({ resource, body }) => {
-      expect(resource).toBe('pokemons')
+    put: ({ body }) => {
       return { ...body, replaced: true }
+    },
+    patch: ({ body }) => {
+      return { ...body, updated: true }
     },
   }
 
@@ -46,10 +45,12 @@ describe('requestBodyInterceptors that return a (new or changed) request body', 
       .send({ name: 'Pikachu' })
       .set('Content-Type', 'application/json')
     expect(postResponse.statusCode).toEqual(201)
+    expect(postResponse.body.name).toEqual('Pikachu')
+    expect(postResponse.body.replaced).toBeUndefined()
+
     const id = postResponse.header.location.split('/').pop()
 
     // Send a PUT request to the id.
-    // The request body is empty because that's not important for this test.
     const response = await request(tembaServer)
       .put(`${resourceUrl}/${id}`)
       .send({ name: 'Mew' })
@@ -59,5 +60,31 @@ describe('requestBodyInterceptors that return a (new or changed) request body', 
     expect(response.body.id).toEqual(id)
     expect(response.body.name).toEqual('Mew')
     expect(response.body.replaced).toEqual(true)
+  })
+
+  test('PATCH with a requestBodyInterceptor that returns a request body', async () => {
+    const resourceUrl = '/pokemons'
+
+    // First create a resource, so we have an id to PUT to.
+    const postResponse = await request(tembaServer)
+      .post(resourceUrl)
+      .send({ name: 'Pikachu' })
+      .set('Content-Type', 'application/json')
+    expect(postResponse.statusCode).toEqual(201)
+    expect(postResponse.body.name).toEqual('Pikachu')
+    expect(postResponse.body.updated).toBeUndefined()
+
+    const id = postResponse.header.location.split('/').pop()
+
+    // Send a PUT request to the id.
+    const response = await request(tembaServer)
+      .patch(`${resourceUrl}/${id}`)
+      .send({ name: 'Mew' })
+      .set('Content-Type', 'application/json')
+
+    expect(response.statusCode).toEqual(200)
+    expect(response.body.id).toEqual(id)
+    expect(response.body.name).toEqual('Mew')
+    expect(response.body.updated).toEqual(true)
   })
 })

--- a/test/integration/requestBodyInterceptor/requestBodyInterceptor-void.test.ts
+++ b/test/integration/requestBodyInterceptor/requestBodyInterceptor-void.test.ts
@@ -2,19 +2,11 @@ import request from 'supertest'
 import { Config } from '../../../src/config'
 import createServer from '../createServer'
 
-//TODO add patch
-
 describe('requestBodyInterceptors that return nothing (void) to indicate nothing should be done', () => {
   const requestBodyInterceptor = {
-    post: ({ resource, body }) => {
-      expect(['movies', 'pokemons']).toContain(resource)
-      if (resource === 'movies') expect(body).toEqual({})
-      if (resource === 'pokemons') expect(body).toEqual({ name: 'Pikachu' })
-    },
-    put: ({ resource, body }) => {
-      expect(resource).toBe('pokemons')
-      expect(body).toEqual({})
-    },
+    post: ({ resource, body }) => {},
+    put: ({ resource, body }) => {},
+    patch: ({ resource, body }) => {},
   }
 
   const tembaServer = createServer({ requestBodyInterceptor } as unknown as Config)
@@ -43,6 +35,24 @@ describe('requestBodyInterceptors that return nothing (void) to indicate nothing
     // Send a PUT request to the id.
     // The request body is empty because that's not important for this test.
     const response = await request(tembaServer).put(`${resourceUrl}/${id}`)
+
+    expect(response.statusCode).toEqual(200)
+  })
+
+  test('PATCH with a requestBodyInterceptor that returns void', async () => {
+    const resourceUrl = '/pokemons'
+
+    // First create a resource, so we have an id to PUT to.
+    const postResponse = await request(tembaServer)
+      .post(resourceUrl)
+      .send({ name: 'Pikachu' })
+      .set('Content-Type', 'application/json')
+    expect(postResponse.statusCode).toEqual(201)
+    const id = postResponse.header.location.split('/').pop()
+
+    // Send a PATCH request to the id.
+    // The request body is empty because that's not important for this test.
+    const response = await request(tembaServer).patch(`${resourceUrl}/${id}`)
 
     expect(response.statusCode).toEqual(200)
   })

--- a/test/unit/config/config.test.ts
+++ b/test/unit/config/config.test.ts
@@ -2,8 +2,6 @@ import { initConfig } from '../../../src/config'
 import type { Config, ConfigKey, UserConfig } from '../../../src/config'
 import express from 'express'
 
-//TODO Sort everything alphabetically
-
 const assertDefaultConfig = (config: Config, skip?: ConfigKey[]) => {
   if (!skip) skip = []
 

--- a/test/unit/config/config.test.ts
+++ b/test/unit/config/config.test.ts
@@ -9,7 +9,7 @@ const assertDefaultConfig = (config: Config, skip?: ConfigKey[]) => {
     resources: [],
     validateResources: false,
     staticFolder: null,
-    apiPrefix: '',
+    apiPrefix: null,
     connectionString: null,
     cacheControl: 'no-store',
     delay: 0,

--- a/test/unit/config/config.test.ts
+++ b/test/unit/config/config.test.ts
@@ -1,4 +1,122 @@
-// TODO Create tests
-test('TODO...', async () => {
-  expect(1 + 1).toBe(2)
+import { initConfig } from '../../../src/config'
+import type { Config, ConfigKey, UserConfig } from '../../../src/config'
+import express from 'express'
+
+//TODO Sort everything alphabetically
+
+const assertDefaultConfig = (config: Config, skip?: ConfigKey[]) => {
+  if (!skip) skip = []
+
+  const defaultConfig: Config = {
+    resources: [],
+    validateResources: false,
+    staticFolder: null,
+    apiPrefix: '',
+    connectionString: null,
+    cacheControl: 'no-store',
+    delay: 0,
+    requestBodyInterceptor: {
+      post: () => {
+        // do nothing
+      },
+      patch: () => {
+        // do nothing
+      },
+      put: () => {
+        // do nothing
+      },
+    },
+    responseBodyInterceptor: ({ body }) => {
+      return body
+    },
+    customRouter: null,
+    returnNullFields: true,
+    isTesting: false,
+    port: 3000,
+  }
+
+  // Do not check keys that are just containers for other keys.
+  const alwaysSkip = ['requestBodyInterceptor']
+
+  // Some settings are callback functions
+  const callbackKeys = ['responseBodyInterceptor', 'post', 'patch', 'put']
+
+  for (const key in defaultConfig) {
+    if (alwaysSkip.includes(key)) continue
+    if (skip.includes(key as ConfigKey)) continue
+
+    // For callback functions we just wanna know they are functions,
+    // because the actual implementation is tested elsewhere.
+    if (callbackKeys.includes(key)) {
+      expect(config[key]).toBeInstanceOf(Function)
+      continue
+    }
+
+    // All other keys should be equal to the default config.
+    expect(config[key]).toEqual(defaultConfig[key])
+  }
+}
+
+test('No config returns default config', () => {
+  const defaultConfig = initConfig()
+  assertDefaultConfig(defaultConfig)
+})
+
+test('Full user config overrides all defaults', () => {
+  const customRouter = express.Router()
+  customRouter.get('/hello', async (_, res) => {
+    return res.send('Hello, World!')
+  })
+
+  const config = initConfig({
+    resources: ['movies'],
+    staticFolder: 'build',
+    apiPrefix: 'api',
+    connectionString: 'mongodb://localhost:27017',
+    cacheControl: 'no-cache',
+    delay: 1000,
+    requestBodyInterceptor: {
+      post: () => {
+        // do nothing
+      },
+      patch: () => {
+        // do nothing
+      },
+      put: () => {
+        // do nothing
+      },
+    },
+    responseBodyInterceptor: ({ body }) => {
+      return body
+    },
+    customRouter,
+    returnNullFields: false,
+    isTesting: true,
+    port: 3001,
+  })
+
+  expect(config.resources).toEqual(['movies'])
+  expect(config.validateResources).toBe(true)
+  expect(config.staticFolder).toBe('build')
+  expect(config.apiPrefix).toBe('/api/')
+  expect(config.connectionString).toBe('mongodb://localhost:27017')
+  expect(config.cacheControl).toBe('no-cache')
+  expect(config.delay).toBe(1000)
+  expect(config.requestBodyInterceptor.post).toBeInstanceOf(Function)
+  expect(config.requestBodyInterceptor.patch).toBeInstanceOf(Function)
+  expect(config.requestBodyInterceptor.put).toBeInstanceOf(Function)
+  expect(config.responseBodyInterceptor).toBeInstanceOf(Function)
+  expect(config.customRouter).not.toBeNull()
+  expect(config.returnNullFields).toBe(false)
+  expect(config.isTesting).toBe(true)
+  expect(config.port).toBe(3001)
+})
+
+test('Partial user config applies those, but leaves the rest at default', () => {
+  const config = initConfig({
+    apiPrefix: 'api',
+  })
+
+  expect(config.apiPrefix).toBe('/api/')
+  assertDefaultConfig(config, ['apiPrefix'])
 })


### PR DESCRIPTION
# Fixes
* When using `apiPrefix`, `PATCH` requests to resources on the root URL now also return a `404 Not Found`

# Tests
* Add tests for the `initConfig`, which merges the user provided config to the default config.
* Add tests for `PATCH` requests when using `requestBodyInterceptor`
* More tests for resources + HTTP methods when using an `apiPrefix`

# Miscellaneous
* TypeScript types fixes
* Added code comments here and there to clarify things