### PR TITLE
chore: enable verbatimModuleSyntax and fix type imports accordingly

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import type { ConfiguredSchemas } from '../schema/types'
-import { RequestBodyInterceptor } from '../requestBodyInterceptor/types'
-import { ResponseBodyInterceptor } from '../responseBodyInterceptor/types'
+import type { RequestBodyInterceptor } from '../requestBodyInterceptor/types'
+import type { ResponseBodyInterceptor } from '../responseBodyInterceptor/types'
 
 export type Config = {
   validateResources: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import express, { Response, Request, json } from 'express'
+import express, { json } from 'express'
+import type { Response, Request } from 'express'
 import morgan from 'morgan'
 import { createQueries } from './queries/queries'
 import { initConfig } from './config'

--- a/src/queries/in-memory.ts
+++ b/src/queries/in-memory.ts
@@ -1,4 +1,4 @@
-import { Item, ItemWithoutId, Queries } from './types'
+import type { Item, ItemWithoutId, Queries } from './types'
 
 const data: { [key: string]: Item[] } = {}
 

--- a/src/queries/mongo.ts
+++ b/src/queries/mongo.ts
@@ -1,5 +1,5 @@
-import { Db, connect } from '@rakered/mongo'
-import { Item, ItemWithoutId, Queries } from './types'
+import { type Db, connect } from '@rakered/mongo'
+import type { Item, ItemWithoutId, Queries } from './types'
 
 let uri: string
 let db: Db

--- a/src/requestHandlers/patch.ts
+++ b/src/requestHandlers/patch.ts
@@ -4,7 +4,7 @@ import { removeNullFields } from './utils'
 import type { ValidateFunctionPerResource } from '../schema/types'
 import type { PatchRequest } from './types'
 import type { Queries } from '../queries/types'
-import { RequestBodyInterceptor } from '../requestBodyInterceptor/types'
+import type { RequestBodyInterceptor } from '../requestBodyInterceptor/types'
 
 export const createPatchRoutes = (
   queries: Queries,

--- a/src/requestHandlers/post.ts
+++ b/src/requestHandlers/post.ts
@@ -5,7 +5,7 @@ import { validate } from '../schema/validate'
 import type { ValidateFunctionPerResource } from '../schema/types'
 import type { PostRequest } from './types'
 import type { ItemWithoutId, Queries } from '../queries/types'
-import { RequestBodyInterceptor } from '../requestBodyInterceptor/types'
+import type { RequestBodyInterceptor } from '../requestBodyInterceptor/types'
 
 export const createPostRoutes = (
   queries: Queries,

--- a/src/requestHandlers/put.ts
+++ b/src/requestHandlers/put.ts
@@ -4,7 +4,7 @@ import { removeNullFields } from './utils'
 import type { ValidateFunctionPerResource } from '../schema/types'
 import type { PutRequest } from './types'
 import type { Queries } from '../queries/types'
-import { RequestBodyInterceptor } from '../requestBodyInterceptor/types'
+import type { RequestBodyInterceptor } from '../requestBodyInterceptor/types'
 
 export const createPutRoutes = (
   queries: Queries,

--- a/src/requestHandlers/types.ts
+++ b/src/requestHandlers/types.ts
@@ -1,5 +1,3 @@
-import type { Item } from '../queries/types'
-
 export type UrlInfo = {
   resource: string | null
   id: string | null

--- a/src/resourceRouter.ts
+++ b/src/resourceRouter.ts
@@ -1,10 +1,11 @@
-import express, { Response, Request } from 'express'
+import express from 'express'
+import type { Response, Request } from 'express'
 import { getRequestHandler } from './requestHandlers'
 import { parseUrl } from './urls/urlParser'
-import { TembaRequest, TembaResponse } from './requestHandlers/types'
-import { Queries } from './queries/types'
-import { CompiledSchemas } from './schema/types'
-import { RouterConfig } from './config'
+import type { TembaRequest, TembaResponse } from './requestHandlers/types'
+import type { Queries } from './queries/types'
+import type { CompiledSchemas } from './schema/types'
+import type { RouterConfig } from './config'
 
 export const createResourceRouter = (
   queries: Queries,

--- a/src/responseBodyInterceptor/interceptResponseBody.ts
+++ b/src/responseBodyInterceptor/interceptResponseBody.ts
@@ -1,4 +1,4 @@
-import { InterceptedResponse, ResponseBodyInterceptor } from './types'
+import type { InterceptedResponse, ResponseBodyInterceptor } from './types'
 
 export const interceptResponseBody = (
   interceptor: ResponseBodyInterceptor,

--- a/src/responseBodyInterceptor/types.ts
+++ b/src/responseBodyInterceptor/types.ts
@@ -1,4 +1,4 @@
-import { Item } from '../queries/types'
+import type { Item } from '../queries/types'
 
 export type InterceptedResponse =
   | {

--- a/src/schema/compile.ts
+++ b/src/schema/compile.ts
@@ -1,5 +1,5 @@
-import Ajv, { AnySchema } from 'ajv'
-import { CompiledSchemas, ConfiguredSchemas } from './types'
+import Ajv, { type AnySchema } from 'ajv'
+import type { CompiledSchemas, ConfiguredSchemas } from './types'
 
 export const compileSchemas = (configuredSchemas: ConfiguredSchemas | null) => {
   // Turn the configured schemas into compiled schemas

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -1,4 +1,4 @@
-import { ValidateFunction } from 'ajv'
+import type { ValidateFunction } from 'ajv'
 
 export type ConfiguredSchemas = {
   [resource: string]: ConfiguredResourceSchema

--- a/src/schema/validate.ts
+++ b/src/schema/validate.ts
@@ -1,5 +1,5 @@
-import { ValidateFunction } from 'ajv'
-import { ValidationResult } from './types'
+import type { ValidateFunction } from 'ajv'
+import type { ValidationResult } from './types'
 
 export const validate = (body: unknown, validate?: ValidateFunction<unknown>): ValidationResult => {
   if (!validate) return { isValid: true }

--- a/test/integration/requestBodyInterceptor/requestBodyInterceptor-change-requestBody.test.ts
+++ b/test/integration/requestBodyInterceptor/requestBodyInterceptor-change-requestBody.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from 'vitest'
 import request from 'supertest'
-import { UserConfig } from '../../../src/config'
+import type { UserConfig } from '../../../src/config'
 import createServer from '../createServer'
-import { RequestBodyInterceptor } from '../../../src/requestBodyInterceptor/types'
+import type { RequestBodyInterceptor } from '../../../src/requestBodyInterceptor/types'
 
 describe('requestBodyInterceptors that return a (new or changed) request body object', () => {
   const requestBodyInterceptor: RequestBodyInterceptor = {

--- a/test/integration/requestBodyInterceptor/requestBodyInterceptor-error-string.test.ts
+++ b/test/integration/requestBodyInterceptor/requestBodyInterceptor-error-string.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from 'vitest'
 import request from 'supertest'
-import { UserConfig } from '../../../src/config'
+import type { UserConfig } from '../../../src/config'
 import createServer from '../createServer'
-import { RequestBodyInterceptor } from '../../../src/requestBodyInterceptor/types'
+import type { RequestBodyInterceptor } from '../../../src/requestBodyInterceptor/types'
 
 describe('requestBodyInterceptors that return a string to indicate a 400 Bad Request should be returned', () => {
   const requestBodyInterceptor: RequestBodyInterceptor = {

--- a/test/integration/requestBodyInterceptor/requestBodyInterceptor-invalid-return-types.test.ts
+++ b/test/integration/requestBodyInterceptor/requestBodyInterceptor-invalid-return-types.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from 'vitest'
 import request from 'supertest'
-import { UserConfig } from '../../../src/config'
+import type { UserConfig } from '../../../src/config'
 import createServer from '../createServer'
-import { RequestBodyInterceptor } from '../../../src/requestBodyInterceptor/types'
+import type { RequestBodyInterceptor } from '../../../src/requestBodyInterceptor/types'
 
 describe('requestBodyInterceptors does not return an object', () => {
   const getResponse = (resource: string | null) => {

--- a/test/integration/requestBodyInterceptor/requestBodyInterceptor-void.test.ts
+++ b/test/integration/requestBodyInterceptor/requestBodyInterceptor-void.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import request from 'supertest'
-import { UserConfig } from '../../../src/config'
+import type { UserConfig } from '../../../src/config'
 import createServer from '../createServer'
 
 describe('requestBodyInterceptors that return nothing (void) to indicate nothing should be done', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "target": "es2022",
-    // "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": true,
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",


### PR DESCRIPTION
The `verbatimModuleSyntax` tsconfig setting makes sure types are imported indicating they are types, as opposed to normal imports.