### PR TITLE
Root URL stuff.... ... ... ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The `OPTIONS` method also works, but because Temba uses Express' default impleme
 
 Temba supports JSON only.
 
-Request bodies sent with a `POST`, `PATCH`, and `PUT` requests are valid when the request body is either empty, or when it's valid formatted JSON. Adding a `Content-Type: application/json` header is required. If you send a request with invalid formatted JSON, a `400 Bad Request` response is returned.
+Request bodies sent with a `POST`, `PATCH`, and `PUT` requests are valid when the request body is either empty, or when it's valid formatted JSON. If you send a request with invalid formatted JSON, a `400 Bad Request` response is returned.
 
 Any valid formatted JSON is accepted and stored. If you want to validate or even change the JSON in the request bodies, check out [JSON Schema request body validation](#json-schema-request-body-validation) and the [`requestInterceptor`](#request-validation-or-mutation).
 

--- a/test/integration/requestInterceptor/requestInterceptor-change-requestBody.test.ts
+++ b/test/integration/requestInterceptor/requestInterceptor-change-requestBody.test.ts
@@ -23,10 +23,7 @@ describe('requestInterceptors that return a (new or changed) request body object
     const resourceUrl = '/movies'
 
     // Send a POST request.
-    const response = await request(tembaServer)
-      .post(resourceUrl)
-      .send({ title: 'Star Wars' })
-      .set('Content-Type', 'application/json')
+    const response = await request(tembaServer).post(resourceUrl).send({ title: 'Star Wars' })
 
     expect(response.statusCode).toEqual(201)
     expect(response.body.title).toEqual('The Matrix')
@@ -43,10 +40,7 @@ describe('requestInterceptors that return a (new or changed) request body object
     const resourceUrl = '/pokemons'
 
     // First create a resource, so we have an id to PUT to.
-    const postResponse = await request(tembaServer)
-      .post(resourceUrl)
-      .send({ name: 'Pikachu' })
-      .set('Content-Type', 'application/json')
+    const postResponse = await request(tembaServer).post(resourceUrl).send({ name: 'Pikachu' })
     expect(postResponse.statusCode).toEqual(201)
     expect(postResponse.body.name).toEqual('Pikachu')
     expect(postResponse.body.replaced).toBeUndefined()
@@ -54,10 +48,7 @@ describe('requestInterceptors that return a (new or changed) request body object
     const id = postResponse.header.location?.split('/').pop()
 
     // Send a PUT request to the id.
-    const response = await request(tembaServer)
-      .put(`${resourceUrl}/${id}`)
-      .send({ name: 'Mew' })
-      .set('Content-Type', 'application/json')
+    const response = await request(tembaServer).put(`${resourceUrl}/${id}`).send({ name: 'Mew' })
 
     expect(response.statusCode).toEqual(200)
     expect(response.body.id).toEqual(id)
@@ -69,10 +60,7 @@ describe('requestInterceptors that return a (new or changed) request body object
     const resourceUrl = '/pokemons'
 
     // First create a resource, so we have an id to PUT to.
-    const postResponse = await request(tembaServer)
-      .post(resourceUrl)
-      .send({ name: 'Pikachu' })
-      .set('Content-Type', 'application/json')
+    const postResponse = await request(tembaServer).post(resourceUrl).send({ name: 'Pikachu' })
     expect(postResponse.statusCode).toEqual(201)
     expect(postResponse.body.name).toEqual('Pikachu')
     expect(postResponse.body.updated).toBeUndefined()
@@ -80,10 +68,7 @@ describe('requestInterceptors that return a (new or changed) request body object
     const id = postResponse.header.location?.split('/').pop()
 
     // Send a PATCH request to the id.
-    const response = await request(tembaServer)
-      .patch(`${resourceUrl}/${id}`)
-      .send({ name: 'Mew' })
-      .set('Content-Type', 'application/json')
+    const response = await request(tembaServer).patch(`${resourceUrl}/${id}`).send({ name: 'Mew' })
 
     expect(response.statusCode).toEqual(200)
     expect(response.body.id).toEqual(id)

--- a/test/integration/requestInterceptor/requestInterceptor-error-string.test.ts
+++ b/test/integration/requestInterceptor/requestInterceptor-error-string.test.ts
@@ -36,10 +36,7 @@ describe('requestInterceptors that return a string to indicate a 400 Bad Request
     const resourceUrl = '/' + expectedResource
 
     // First create a resource, so we have an id to PUT to.
-    const postResponse = await request(tembaServer)
-      .post(resourceUrl)
-      .send({ name: 'Pikachu' })
-      .set('Content-Type', 'application/json')
+    const postResponse = await request(tembaServer).post(resourceUrl).send({ name: 'Pikachu' })
     expect(postResponse.statusCode).toEqual(201)
     const id = postResponse.header.location?.split('/').pop()
 
@@ -56,10 +53,7 @@ describe('requestInterceptors that return a string to indicate a 400 Bad Request
     const resourceUrl = '/' + expectedResource
 
     // First create a resource, so we have an id to PUT to.
-    const postResponse = await request(tembaServer)
-      .post(resourceUrl)
-      .send({ name: 'Pikachu' })
-      .set('Content-Type', 'application/json')
+    const postResponse = await request(tembaServer).post(resourceUrl).send({ name: 'Pikachu' })
     expect(postResponse.statusCode).toEqual(201)
     const id = postResponse.header.location?.split('/').pop()
 

--- a/test/integration/requestInterceptor/requestInterceptor-invalid-return-types.test.ts
+++ b/test/integration/requestInterceptor/requestInterceptor-invalid-return-types.test.ts
@@ -28,28 +28,19 @@ describe('requestInterceptors does not return an object', () => {
 
   test('requestInterceptor returns the original request body when something else than an object or string is returned', async () => {
     // Send POST requests.
-    let response = await request(tembaServer)
-      .post('/return-number')
-      .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
+    let response = await request(tembaServer).post('/return-number').send({ name: 'Jane' })
     expect(response.statusCode).toEqual(201)
     expect(response.body.name).toEqual('Jane')
 
     const numberId = response.header.location?.split('/').pop()
 
-    response = await request(tembaServer)
-      .post('/return-array')
-      .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
+    response = await request(tembaServer).post('/return-array').send({ name: 'Jane' })
     expect(response.statusCode).toEqual(201)
     expect(response.body.name).toEqual('Jane')
 
     const arrayId = response.header.location?.split('/').pop()
 
-    response = await request(tembaServer)
-      .post('/return-boolean')
-      .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
+    response = await request(tembaServer).post('/return-boolean').send({ name: 'Jane' })
     expect(response.statusCode).toEqual(201)
     expect(response.body.name).toEqual('Jane')
 
@@ -59,21 +50,18 @@ describe('requestInterceptors does not return an object', () => {
     response = await request(tembaServer)
       .put('/return-number/' + numberId)
       .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
     expect(response.statusCode).toEqual(200)
     expect(response.body.name).toEqual('Jane')
 
     response = await request(tembaServer)
       .put('/return-array/' + arrayId)
       .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
     expect(response.statusCode).toEqual(200)
     expect(response.body.name).toEqual('Jane')
 
     response = await request(tembaServer)
       .put('/return-boolean/' + booleanId)
       .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
     expect(response.statusCode).toEqual(200)
     expect(response.body.name).toEqual('Jane')
 
@@ -81,21 +69,18 @@ describe('requestInterceptors does not return an object', () => {
     response = await request(tembaServer)
       .patch('/return-number/' + numberId)
       .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
     expect(response.statusCode).toEqual(200)
     expect(response.body.name).toEqual('Jane')
 
     response = await request(tembaServer)
       .patch('/return-array/' + arrayId)
       .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
     expect(response.statusCode).toEqual(200)
     expect(response.body.name).toEqual('Jane')
 
     response = await request(tembaServer)
       .patch('/return-boolean/' + booleanId)
       .send({ name: 'Jane' })
-      .set('Content-Type', 'application/json')
     expect(response.statusCode).toEqual(200)
     expect(response.body.name).toEqual('Jane')
   })

--- a/test/integration/requestInterceptor/requestInterceptor-void.test.ts
+++ b/test/integration/requestInterceptor/requestInterceptor-void.test.ts
@@ -26,10 +26,7 @@ describe('requestInterceptors that return nothing (void) to indicate nothing sho
     const resourceUrl = '/pokemons'
 
     // First create a resource, so we have an id to PUT to.
-    const postResponse = await request(tembaServer)
-      .post(resourceUrl)
-      .send({ name: 'Pikachu' })
-      .set('Content-Type', 'application/json')
+    const postResponse = await request(tembaServer).post(resourceUrl).send({ name: 'Pikachu' })
     expect(postResponse.statusCode).toEqual(201)
     const id = postResponse.header.location?.split('/').pop()
 
@@ -44,10 +41,7 @@ describe('requestInterceptors that return nothing (void) to indicate nothing sho
     const resourceUrl = '/pokemons'
 
     // First create a resource, so we have an id to PUT to.
-    const postResponse = await request(tembaServer)
-      .post(resourceUrl)
-      .send({ name: 'Pikachu' })
-      .set('Content-Type', 'application/json')
+    const postResponse = await request(tembaServer).post(resourceUrl).send({ name: 'Pikachu' })
     expect(postResponse.statusCode).toEqual(201)
     const id = postResponse.header.location?.split('/').pop()
 

--- a/test/integration/schema-validation.test.ts
+++ b/test/integration/schema-validation.test.ts
@@ -32,10 +32,7 @@ test('Schema validation POST/PUT/PATCH', async () => {
   } satisfies UserConfig)
 
   // POST only the required brand
-  let response = await request(tembaServer)
-    .post(resourceUrl)
-    .send({ brand: 'Mercedes-Benz' })
-    .set('Content-Type', 'application/json')
+  let response = await request(tembaServer).post(resourceUrl).send({ brand: 'Mercedes-Benz' })
   expect(response.statusCode).toEqual(201)
   expect(response.body.message).toBeUndefined()
   const mercedesId = response.body.id
@@ -44,7 +41,6 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .put(resourceUrl + mercedesId)
     .send({ brand: 'Mercedes-Benz', price: 100000 })
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(200)
   expect(response.body.message).toBeUndefined()
 
@@ -52,7 +48,6 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .put(resourceUrl + mercedesId)
     .send({})
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(400)
   expect(response.body.message.length).toBeGreaterThan(0)
 
@@ -60,7 +55,6 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .put(resourceUrl + mercedesId)
     .send({ unknown: 'property' })
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(400)
   expect(response.body.message.length).toBeGreaterThan(0)
 
@@ -68,7 +62,6 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .patch(resourceUrl + mercedesId)
     .send({})
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(200)
   expect(response.body.message).toBeUndefined()
 
@@ -76,7 +69,6 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .patch(resourceUrl + mercedesId)
     .send({ brand: 'Mercedes-Benz' })
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(200)
   expect(response.body.message).toBeUndefined()
 
@@ -84,7 +76,6 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .patch(resourceUrl + mercedesId)
     .send({ price: 100000 })
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(200)
   expect(response.body.message).toBeUndefined()
 
@@ -92,7 +83,6 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .patch(resourceUrl + mercedesId)
     .send({ brand: 'Mercedes-Benz', price: 100000 })
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(200)
   expect(response.body.message).toBeUndefined()
 
@@ -100,31 +90,21 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .patch(resourceUrl + mercedesId)
     .send({ unknown: 'property' })
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(400)
   expect(response.body.message.length).toBeGreaterThan(0)
 
   // POST the required brand and the optional price
-  response = await request(tembaServer)
-    .post(resourceUrl)
-    .send({ brand: 'BMW', price: 100000 })
-    .set('Content-Type', 'application/json')
+  response = await request(tembaServer).post(resourceUrl).send({ brand: 'BMW', price: 100000 })
   expect(response.statusCode).toEqual(201)
   expect(response.body.message).toBeUndefined()
 
   // POST without the required brand
-  response = await request(tembaServer)
-    .post(resourceUrl)
-    .send({})
-    .set('Content-Type', 'application/json')
+  response = await request(tembaServer).post(resourceUrl).send({})
   expect(response.statusCode).toEqual(400)
   expect(response.body.message.length).toBeGreaterThan(0)
 
   // POST an invalid brand
-  response = await request(tembaServer)
-    .post(resourceUrl)
-    .send({ brand: 123 })
-    .set('Content-Type', 'application/json')
+  response = await request(tembaServer).post(resourceUrl).send({ brand: 123 })
   expect(response.statusCode).toEqual(400)
   expect(response.body.message.length).toBeGreaterThan(0)
 
@@ -132,15 +112,11 @@ test('Schema validation POST/PUT/PATCH', async () => {
   response = await request(tembaServer)
     .post(resourceUrl)
     .send({ brand: 'Mercedes-Benz', price: 'not a number' })
-    .set('Content-Type', 'application/json')
   expect(response.statusCode).toEqual(400)
   expect(response.body.message.length).toBeGreaterThan(0)
 
   // POST with an unknown property
-  response = await request(tembaServer)
-    .post(resourceUrl)
-    .send({ unknown: 'property' })
-    .set('Content-Type', 'application/json')
+  response = await request(tembaServer).post(resourceUrl).send({ unknown: 'property' })
   expect(response.statusCode).toEqual(400)
   expect(response.body.message.length).toBeGreaterThan(0)
 })
@@ -163,31 +139,19 @@ test('Schema validation per resource', async () => {
   } satisfies UserConfig)
 
   // A car with a brand is valid
-  let response = await request(tembaServer)
-    .post(resourceUrl)
-    .send({ brand: 'Mercedes-Benz' })
-    .set('Content-Type', 'application/json')
+  let response = await request(tembaServer).post(resourceUrl).send({ brand: 'Mercedes-Benz' })
   expect(response.statusCode).toEqual(201)
 
   // A car without a brand is invalid
-  response = await request(tembaServer)
-    .post(resourceUrl)
-    .send({})
-    .set('Content-Type', 'application/json')
+  response = await request(tembaServer).post(resourceUrl).send({})
   expect(response.statusCode).toEqual(400)
 
   // However, the bikes resource does not have a schema,
   // so a bike without a brand is valid
-  response = await request(tembaServer)
-    .post('/bikes/')
-    .send({})
-    .set('Content-Type', 'application/json')
+  response = await request(tembaServer).post('/bikes/').send({})
   expect(response.statusCode).toEqual(201)
 
   // You can even POST nonsense to the bikes resource
-  response = await request(tembaServer)
-    .post('/bikes/')
-    .send({ foo: 'bar' })
-    .set('Content-Type', 'application/json')
+  response = await request(tembaServer).post('/bikes/').send({ foo: 'bar' })
   expect(response.statusCode).toEqual(201)
 })


### PR DESCRIPTION
# New feature

* ...
* ...

# Chore

* Remove `Content-Type` header from requests in tests and docs, because it is not even a request header, and so certainly not required. 🤦🏻 