### PR TITLE
fix: make check to determine connectionString is MongoDB more flexible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "temba",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "temba",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "ISC",
       "dependencies": {
         "@rakered/mongo": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temba",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Get a simple REST API with zero coding in less than 30 seconds (seriously).",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/data/queries.ts
+++ b/src/data/queries.ts
@@ -7,7 +7,7 @@ export const createQueries = (connectionString: string | null) => {
 
   if (connectionString.endsWith('.json')) return createJsonQueries({ filename: connectionString })
 
-  if (connectionString.startsWith('mongodb://')) return createMongoQueries(connectionString)
+  if (connectionString.startsWith('mongodb')) return createMongoQueries(connectionString)
 
   return createJsonQueries({ filename: null })
 }


### PR DESCRIPTION
Not all MongoDB connection strings start with `"mongodb://"`, so let's just check it starts with `"mongodb"`.