### PR TITLE
docs: add allowDeleteCollection setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For every resource (`movies` is just an example), Temba supports the following r
 - `POST /movies` - Create a new movie
 - `PATCH /movies/:id` - Partially update a movie by its ID
 - `PUT /movies/:id` - Fully replace a movie by its ID
-- `DELETE /movies` - Delete all movies
+- `DELETE /movies` - Delete all movies (if configured)
 - `DELETE /movies/:id` - Delete a movie by its ID
 - `HEAD /movies` - Get all movies, but without the response body
 - `HEAD /movies/:id` - Get a movie by its ID, but without the response body
@@ -421,6 +421,7 @@ Here is an example of the config settings for Temba, and how you define them:
 
 ```js
 const config = {
+  allowDeleteCollection: true,
   apiPrefix: 'api',
   cacheControl: 'public, max-age=300',
   connectionString: 'mongodb://localhost:27017/myDatabase',
@@ -463,6 +464,7 @@ These are all the possible settings:
 
 | Config setting            | Description                                                                                | Default value |
 | :------------------------ | :----------------------------------------------------------------------------------------- | :------------ |
+| `allowDeleteCollection`   | Whether a `DELETE` request on a collection is allowed to delete all items. | `false` |
 | `apiPrefix`               | See [API prefix](#api-prefix)                                                              | `null`        |
 | `cacheControl`            | The `Cache-control` response header value for each GET request.                            | `'no-store'`  |
 | `connectionString`        | See [Data persistency](#data-persistency)                                                                    | `null`        |
@@ -472,7 +474,7 @@ These are all the possible settings:
 | `requestInterceptor`  | See [Request validation or mutation](#request-validation-or-mutation)            | `noop`        |
 | `resources`               | See [Allowing specific resources only](#allowing-specific-resources-only)                  | `[]`          |
 | `responseBodyInterceptor` | See [Response body interception](#response-body-interception)                     | `noop`        |
-| `returnNullFields`        | Determines whether fields with a null value should be returned in responses.                        | `true`        |
+| `returnNullFields`        | Whether fields with a null value should be returned in responses.                        | `true`        |
 | `schema`                  | See [JSON Schema request body validation](#json-schema-request-body-validation)                                                                                         | `null`        |
 | `staticFolder`            | See [Static assets](#static-assets)                                                        | `null`        |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "temba",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "temba",
-      "version": "0.26.2",
+      "version": "0.27.0",
       "license": "ISC",
       "dependencies": {
         "@rakered/mongo": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temba",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "description": "Get a simple REST API with zero coding in less than 30 seconds (seriously).",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -18,6 +18,7 @@ export type Config = {
   isTesting: boolean
   port: number
   schemas: ConfiguredSchemas | null
+  allowDeleteCollection: boolean
 }
 
 export type ConfigKey = keyof Config
@@ -31,6 +32,7 @@ export type RouterConfig = Pick<
   | 'requestInterceptor'
   | 'responseBodyInterceptor'
   | 'returnNullFields'
+  | 'allowDeleteCollection'
 >
 
 export type UserConfig = {
@@ -47,6 +49,7 @@ export type UserConfig = {
   isTesting?: boolean
   port?: number
   schemas?: ConfiguredSchemas
+  allowDeleteCollection?: boolean
 }
 
 const defaultConfig: Config = {
@@ -64,6 +67,7 @@ const defaultConfig: Config = {
   isTesting: false,
   port: 3000,
   schemas: null,
+  allowDeleteCollection: false,
 }
 
 export const initConfig = (userConfig?: UserConfig): Config => {
@@ -147,6 +151,10 @@ export const initConfig = (userConfig?: UserConfig): Config => {
 
   if (userConfig.schemas) {
     config.schemas = userConfig.schemas
+  }
+
+  if (!isUndefined(userConfig.allowDeleteCollection)) {
+    config.allowDeleteCollection = userConfig.allowDeleteCollection
   }
 
   return config

--- a/src/requestHandlers/delete.ts
+++ b/src/requestHandlers/delete.ts
@@ -1,7 +1,7 @@
 import type { Queries } from '../data/types'
 import type { DeleteRequest } from './types'
 
-export const createDeleteRoutes = (queries: Queries) => {
+export const createDeleteRoutes = (queries: Queries, allowDeleteCollection: boolean) => {
   const handleDelete = async (req: DeleteRequest) => {
     try {
       const { resource, id } = req
@@ -12,6 +12,9 @@ export const createDeleteRoutes = (queries: Queries) => {
           await queries.deleteById(resource, id)
         }
       } else {
+        if (!allowDeleteCollection) {
+          return { status: 405 }
+        }
         await queries.deleteAll(resource)
       }
 

--- a/src/requestHandlers/index.ts
+++ b/src/requestHandlers/index.ts
@@ -13,8 +13,13 @@ export const getRequestHandler = (
   schemas: CompiledSchemas,
   routerConfig: RouterConfig,
 ) => {
-  const { cacheControl, requestInterceptor, responseBodyInterceptor, returnNullFields } =
-    routerConfig
+  const {
+    cacheControl,
+    requestInterceptor,
+    responseBodyInterceptor,
+    returnNullFields,
+    allowDeleteCollection,
+  } = routerConfig
 
   const handleGet = createGetRoutes(
     queries,
@@ -34,7 +39,7 @@ export const getRequestHandler = (
     schemas.patch,
   )
 
-  const handleDelete = createDeleteRoutes(queries)
+  const handleDelete = createDeleteRoutes(queries, allowDeleteCollection)
 
   return {
     handleGet,

--- a/test/unit/config/config.test.ts
+++ b/test/unit/config/config.test.ts
@@ -18,6 +18,7 @@ const defaultConfig: Config = {
   isTesting: false,
   port: 3000,
   schemas: null,
+  allowDeleteCollection: false,
 }
 
 test('No config returns default config', () => {
@@ -39,6 +40,7 @@ test('No config returns default config', () => {
   expect(initializedConfig.isTesting).toBe(defaultConfig.isTesting)
   expect(initializedConfig.port).toBe(defaultConfig.port)
   expect(initializedConfig.schemas).toBe(defaultConfig.schemas)
+  expect(initializedConfig.allowDeleteCollection).toBe(defaultConfig.allowDeleteCollection)
 })
 
 test('Full user config overrides all defaults', () => {
@@ -85,6 +87,7 @@ test('Full user config overrides all defaults', () => {
         },
       },
     },
+    allowDeleteCollection: true,
   })
 
   expect(config.resources).toEqual(['movies'])
@@ -103,6 +106,7 @@ test('Full user config overrides all defaults', () => {
   expect(config.isTesting).toBe(true)
   expect(config.port).toBe(3001)
   expect(config.schemas).not.toBeNull()
+  expect(config.allowDeleteCollection).toBe(true)
 })
 
 test('Partial user config applies those, but leaves the rest at default', () => {
@@ -126,4 +130,5 @@ test('Partial user config applies those, but leaves the rest at default', () => 
   expect(config.isTesting).toBe(defaultConfig.isTesting)
   expect(config.port).toBe(defaultConfig.port)
   expect(config.schemas).toBe(defaultConfig.schemas)
+  expect(config.allowDeleteCollection).toBe(defaultConfig.allowDeleteCollection)
 })


### PR DESCRIPTION
# Breaking change

From now on, a `DELETE` on a collection, which deletes all items on the collection, is no longer the default.

Example request:

```
DELETE /movies
```

From now on, by default, this will return a `405 Method Not Allowed` response.

If you want to allow deleting entire collections, set the `allowDeleteCollection` setting to `true`:

```
const config = {
  allowDeleteCollection: true,
}
const server = temba.create(config)
```

With this setting, a `DELETE` request to `/movies` will delete all movies, and a `204 No Content` response will be returned.