### PR TITLE
Return 400 Bad Request if an id is either missing or not expected in request URLs and request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Request bodies sent with a `POST`, `PATCH`, and `PUT` requests are valid when th
 
 Any valid formatted JSON is accepted and stored. If you want to validate or even change the JSON in the request bodies, check out [JSON Schema request body validation](#json-schema-request-body-validation) and the [`requestInterceptor`](#request-validation-or-mutation).
 
-IDs are auto generated when creating resources. IDs in the JSON request body are always ignored.
+IDs are auto generated when creating resources.
+
+Providing IDs in the request body of `POST`, `PUT`, or `PATCH` requests is not allowed and will return a `400 Bad Request` response. The same applies to adding an ID in a `POST` request URL, or omitting an ID in a `PUT` or `PATCH` request URL.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "temba",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "temba",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "ISC",
       "dependencies": {
         "@rakered/mongo": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temba",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Get a simple REST API with zero coding in less than 30 seconds (seriously).",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/requestHandlers/types.ts
+++ b/src/requestHandlers/types.ts
@@ -3,6 +3,14 @@ export type UrlInfo = {
   id: string | null
 }
 
+export type RequestInfo = {
+  id: string | null
+  resource: string
+  body: unknown | null
+  host: string | null
+  protocol: string | null
+}
+
 export type ErrorResponse = {
   message: string
   status: number

--- a/src/requestHandlers/types.ts
+++ b/src/requestHandlers/types.ts
@@ -3,13 +3,6 @@ export type UrlInfo = {
   id: string | null
 }
 
-export type RequestInfo = {
-  resource: string
-  id: string | null
-}
-
-export type RequestInfoWithoutId = Omit<RequestInfo, 'id'>
-
 export type ErrorResponse = {
   message: string
   status: number

--- a/src/urls/urlParser.ts
+++ b/src/urls/urlParser.ts
@@ -1,6 +1,4 @@
 export const parseUrl = (url: string) => {
-  if (!url || (url && !url.trim())) return { resource: null, id: null }
-
   const urlSegments = url.split('/').filter((i) => i)
 
   const resource = (urlSegments.length > 0 ? urlSegments[0] : null) ?? null

--- a/test/integration/crud.test.ts
+++ b/test/integration/crud.test.ts
@@ -23,7 +23,6 @@ describe('CRUD', () => {
 
     // Initially, there are no items so a replacing something by id returns a 404.
     const nonExistingItem = {
-      id: 'id_does_not_exist',
       name: 'this should fail',
     }
     const replaceNonExistingResponse = await request(tembaServer)

--- a/test/integration/crud.test.ts
+++ b/test/integration/crud.test.ts
@@ -131,49 +131,6 @@ describe('CRUD', () => {
     expect(getAllResponse3.status).toBe(200)
     expect(getAllResponse2.body.length).toBe(0)
   })
-
-  test('When POSTing and PUTting with ID in request body, ignore ID in body', async () => {
-    const hardCodedIdToIgnore = 'myID'
-
-    // Initially, there are no items so a get all returns an empty array.
-    const getAllResponse = await request(tembaServer).get(resource)
-    expect(getAllResponse.status).toBe(200)
-    expect(getAllResponse.body.length).toBe(0)
-
-    // Create a new item, but ignore the ID in the request body.
-    const newItem = { id: hardCodedIdToIgnore, name: 'newItem' }
-    const createNewResponse = await request(tembaServer).post(resource).send(newItem)
-    const newCreatedItem = createNewResponse.body
-    expect(createNewResponse.status).toBe(201)
-    expect(newCreatedItem.name).toBe('newItem')
-    expect(newCreatedItem.id.length).toBeGreaterThan(0)
-    expect(newCreatedItem.id).not.toEqual(hardCodedIdToIgnore)
-
-    // Replace one item by ID in the URI and ignore the ID in the request body.
-    const replacedItem = { id: hardCodedIdToIgnore, name: 'replacedItem' }
-    const replaceResponse = await request(tembaServer)
-      .put(resource + newCreatedItem.id)
-      .send(replacedItem)
-    expect(replaceResponse.status).toBe(200)
-    expect(replaceResponse.body.name).toBe('replacedItem')
-    expect(replaceResponse.body.id).toEqual(newCreatedItem.id)
-
-    // Update one item by ID in the URI and ignore the ID in the request body.
-    const updatedItem = { id: hardCodedIdToIgnore, name: 'updatedItem' }
-    const updateResponse = await request(tembaServer)
-      .put(resource + newCreatedItem.id)
-      .send(updatedItem)
-    expect(updateResponse.status).toBe(200)
-    expect(updateResponse.body.name).toBe('updatedItem')
-    expect(updateResponse.body.id).toEqual(newCreatedItem.id)
-
-    // Now there is one item. Get all items.
-    const getAllOneItemResponse = await request(tembaServer).get(resource)
-    expect(getAllOneItemResponse.status).toBe(200)
-    expect(getAllOneItemResponse.body.length).toBe(1)
-    expect(getAllOneItemResponse.body[0].name).toBe('updatedItem')
-    expect(getAllOneItemResponse.body[0].id).toBe(newCreatedItem.id)
-  })
 })
 
 describe('DELETE collection', () => {

--- a/test/integration/id.test.ts
+++ b/test/integration/id.test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from 'vitest'
+import request from 'supertest'
+import createServer from './createServer'
+
+// The id is either expected or not allowed in URLs.
+// The id is never allowed in request bodies.
+
+const tembaServer = createServer()
+const resource = '/articles/'
+
+test('When POSTing and PUTting with ID in request body, return bad request', async () => {
+  // TODO De implementatie is een defalt JSON Schema die geen ID toestaat.
+  // Indien er al een JSON Schema is geconfigureerd, dan ID erin mergen?
+
+  // Initially, there are no items
+  const getAllResponse = await request(tembaServer).get(resource)
+  expect(getAllResponse.status).toBe(200)
+  expect(getAllResponse.body.length).toBe(0)
+
+  // A POST with an ID in the request body is a bad request.
+  const newItem = { id: 'some_id', name: 'newItem' }
+  const createNewResponse = await request(tembaServer).post(resource).send(newItem)
+  expect(createNewResponse.status).toBe(400)
+
+  // A PUT with an ID in the request body is a bad request.
+  const replacedItem = { id: 'some_id', name: 'replacedItem' }
+  const replaceResponse = await request(tembaServer)
+    .put(resource + '/some_id')
+    .send(replacedItem)
+  expect(replaceResponse.status).toBe(400)
+
+  // A PATCH with an ID in the request body is a bad request.
+  const updatedItem = { id: 'some_id', name: 'updatedItem' }
+  const updateResponse = await request(tembaServer)
+    .patch(resource + '/some_id')
+    .send(updatedItem)
+  expect(updateResponse.status).toBe(400)
+
+  // Because all requests failed, there are still no items.
+  const getAllResponse2 = await request(tembaServer).get(resource)
+  expect(getAllResponse2.status).toBe(200)
+  expect(getAllResponse2.body.length).toBe(0)
+})
+
+//TODO Imlementatie is dat in de URL er gewoon niks achter de resource mag staan...
+// Volgens mij kan dit ongeacht de method
+
+test('PUT without ID in URL returns 400 Bad Request because not enough info is provided', async () => {
+  const response = await request(tembaServer).put(resource).send({ name: 'newItem' })
+  expect(response.status).toBe(400)
+})
+
+test('PATCH without ID in URL returns 400 Bad Request because not enough info is provided', async () => {
+  const response = await request(tembaServer).patch(resource).send({ name: 'newItem' })
+  expect(response.status).toBe(400)
+})
+
+test('Supplying an id in the URL for POST is a bad request because a client can not determine the id', async () => {
+  const response = await request(tembaServer)
+    .post(resource + 'id_does_not_exist')
+    .send({ name: 'newItem' })
+
+  expect(response.status).toBe(400)
+})

--- a/test/unit/urls/urlParser.test.ts
+++ b/test/unit/urls/urlParser.test.ts
@@ -1,7 +1,6 @@
 import { test, expect } from 'vitest'
 import { parseUrl } from '../../../src/urls/urlParser'
 
-const noResourceAndNoId = { resource: null, id: null }
 const resourceOnly = { resource: 'stuff', id: null }
 const resourceAndId = { resource: 'stuff', id: 'foo' }
 
@@ -34,14 +33,6 @@ test.each([
   ['stuff/foo/bar/', resourceAndId],
   ['/stuff/foo/bar/', resourceAndId],
 ])("URL '%s' has additional path items next to a resource and id: %o", (url, expected) => {
-  const actual = parseUrl(url)
-  expect(actual).toEqual(expected)
-})
-
-test.each([
-  ['', noResourceAndNoId],
-  [' ', noResourceAndNoId],
-])("URL '%s' has no resource and id: %o", (url, expected) => {
   const actual = parseUrl(url)
   expect(actual).toEqual(expected)
 })


### PR DESCRIPTION
# Breaking change

Providing IDs in the request body of `POST`, `PUT`, or `PATCH` requests is not allowed and will return a `400 Bad Request` response. The same applies to adding an ID in a `POST` request URL, or omitting an ID in a `PUT` or `PATCH` request URL.

Until now, IDs in request URLs and request bodies were ignored, and for missing IDs in URLs a `404 Not Found` was returned.

Now this has been unified to a `400 Bad Request`, because you are trying something that isn't supported, so let's be clear about that.
