### PR TITLE
Request interceptor remaining http methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,23 @@ It allows you to implement your own validation, or even change the request body.
 ```js
 const config = {
   requestInterceptor: {
+    get: ({ resource, id }) => {
+      //...
+    },
     post: ({ resource, body }) => {
       // Validate, or even change the request body
     },
-    put: ({ resource, body }) => {
+    put: ({ resource, id, body }) => {
       // Validate, or even change the request body
     },
-    patch: ({ resource, body }) => {
+    patch: ({ resource, id, body }) => {
       // Validate, or even change the request body
+    },
+    delete: ({ resource, id }) => {
+      //...
+    },
+    head: ({ resource, id }) => {
+      //...
     },
   },
 }
@@ -280,11 +289,10 @@ const config = {
 const server = temba.create(config)
 ```
 
-> At the moment, only `POST`, `PATCH`, and `PUT` requests can be intercepted.
 
-The `requestInterceptor` is an object with a `post`, and/or `patch`, and/or `put` field, which contains the callback function you want Temba to call before the JSON is persisted.
+The `requestInterceptor` is an object with fields for each of the HTTP methods you might want to intercept, and the callback function you want Temba to call, before processing the request, i.e. going to the database.
 
-The callback function receives an object containing the `resource`, which for example is `movies` if you request `POST /movies`, and the `body`, which is the JSON object of the request body.
+Each callback function receives an object containing the `resource` (e.g. `"movies"`). Depending on the HTTP method, also the `id` from the URL, and the request `body` are provided. `body` is a JSON object of the request body.
 
 Your callback function can return the following things:
 
@@ -438,14 +446,23 @@ const config = {
   delay: 500,
   port: 4321,
   requestInterceptor: {
+    get: ({ resource, id }) => {
+      //...
+    },
     post: ({ resource, body }) => {
       // Validate, or even change the request body
     },
-    patch: ({ resource, body }) => {
+    put: ({ resource, id, body }) => {
       // Validate, or even change the request body
     },
-    put: ({ resource, body }) => {
+    patch: ({ resource, id, body }) => {
       // Validate, or even change the request body
+    },
+    delete: ({ resource, id }) => {
+      //...
+    },
+    head: ({ resource, id }) => {
+      //...
     },
   },
   resources: ['movies', 'actors'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "temba",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "temba",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "ISC",
       "dependencies": {
         "@rakered/mongo": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temba",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Get a simple REST API with zero coding in less than 30 seconds (seriously).",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -110,6 +110,12 @@ export const initConfig = (userConfig?: UserConfig): Config => {
     config.requestInterceptor = config.requestInterceptor || {}
 
     if (
+      userConfig.requestInterceptor.get &&
+      typeof userConfig.requestInterceptor.get === 'function'
+    ) {
+      config.requestInterceptor.get = userConfig.requestInterceptor.get
+    }
+    if (
       userConfig.requestInterceptor.post &&
       typeof userConfig.requestInterceptor.post === 'function'
     ) {
@@ -126,6 +132,12 @@ export const initConfig = (userConfig?: UserConfig): Config => {
       typeof userConfig.requestInterceptor.put === 'function'
     ) {
       config.requestInterceptor.put = userConfig.requestInterceptor.put
+    }
+    if (
+      userConfig.requestInterceptor.delete &&
+      typeof userConfig.requestInterceptor.delete === 'function'
+    ) {
+      config.requestInterceptor.delete = userConfig.requestInterceptor.delete
     }
   }
 

--- a/src/requestHandlers/delete.ts
+++ b/src/requestHandlers/delete.ts
@@ -1,10 +1,28 @@
+import { TembaError } from '..'
 import type { Queries } from '../data/types'
+import { interceptDeleteRequest } from '../requestInterceptor/interceptRequest'
+import type { RequestInterceptor } from '../requestInterceptor/types'
 import type { DeleteRequest } from './types'
 
-export const createDeleteRoutes = (queries: Queries, allowDeleteCollection: boolean) => {
+export const createDeleteRoutes = (
+  queries: Queries,
+  allowDeleteCollection: boolean,
+  requestInterceptor: RequestInterceptor | null,
+) => {
   const handleDelete = async (req: DeleteRequest) => {
     try {
       const { resource, id } = req
+
+      if (requestInterceptor?.delete) {
+        try {
+          interceptDeleteRequest(requestInterceptor.delete, resource, id)
+        } catch (error: unknown) {
+          return {
+            status: error instanceof TembaError ? error.statusCode : 500,
+            body: { message: (error as Error).message },
+          }
+        }
+      }
 
       if (id) {
         const item = await queries.getById(resource, id)

--- a/src/requestHandlers/index.ts
+++ b/src/requestHandlers/index.ts
@@ -24,6 +24,7 @@ export const getRequestHandler = (
   const handleGet = createGetRoutes(
     queries,
     cacheControl,
+    requestInterceptor,
     responseBodyInterceptor,
     returnNullFields,
   )
@@ -39,7 +40,7 @@ export const getRequestHandler = (
     schemas.patch,
   )
 
-  const handleDelete = createDeleteRoutes(queries, allowDeleteCollection)
+  const handleDelete = createDeleteRoutes(queries, allowDeleteCollection, requestInterceptor)
 
   return {
     handleGet,

--- a/src/requestHandlers/patch.ts
+++ b/src/requestHandlers/patch.ts
@@ -1,4 +1,4 @@
-import { interceptRequest } from '../requestInterceptor/interceptRequest'
+import { interceptPatchRequest } from '../requestInterceptor/interceptRequest'
 import { validate } from '../schema/validate'
 import { removeNullFields } from './utils'
 import type { ValidateFunctionPerResource } from '../schema/types'
@@ -25,7 +25,7 @@ export const createPatchRoutes = (
       let body2 = body
       if (requestInterceptor?.patch) {
         try {
-          body2 = interceptRequest(requestInterceptor.patch, resource, body)
+          body2 = interceptPatchRequest(requestInterceptor.patch, resource, id, body)
         } catch (error: unknown) {
           return {
             status: error instanceof TembaError ? error.statusCode : 500,

--- a/src/requestHandlers/post.ts
+++ b/src/requestHandlers/post.ts
@@ -1,5 +1,5 @@
 import { format } from 'url'
-import { interceptRequest } from '../requestInterceptor/interceptRequest'
+import { interceptPostRequest } from '../requestInterceptor/interceptRequest'
 import { removeNullFields } from './utils'
 import { validate } from '../schema/validate'
 import type { ValidateFunctionPerResource } from '../schema/types'
@@ -26,7 +26,7 @@ export const createPostRoutes = (
       let body2 = body
       if (requestInterceptor?.post) {
         try {
-          body2 = interceptRequest(requestInterceptor.post, resource, body)
+          body2 = interceptPostRequest(requestInterceptor.post, resource, body)
         } catch (error: unknown) {
           return {
             status: error instanceof TembaError ? error.statusCode : 500,

--- a/src/requestHandlers/put.ts
+++ b/src/requestHandlers/put.ts
@@ -1,4 +1,4 @@
-import { interceptRequest } from '../requestInterceptor/interceptRequest'
+import { interceptPutRequest } from '../requestInterceptor/interceptRequest'
 import { validate } from '../schema/validate'
 import { removeNullFields } from './utils'
 import type { ValidateFunctionPerResource } from '../schema/types'
@@ -25,7 +25,7 @@ export const createPutRoutes = (
       let body2 = body
       if (requestInterceptor?.put) {
         try {
-          body2 = interceptRequest(requestInterceptor.put, resource, body)
+          body2 = interceptPutRequest(requestInterceptor.put, resource, id, body)
         } catch (error: unknown) {
           return {
             status: error instanceof TembaError ? error.statusCode : 500,

--- a/src/requestHandlers/types.ts
+++ b/src/requestHandlers/types.ts
@@ -9,6 +9,7 @@ export type RequestInfo = {
   body: unknown | null
   host: string | null
   protocol: string | null
+  method: string
 }
 
 export type ErrorResponse = {
@@ -22,6 +23,7 @@ export type TembaRequest = {
 
 export type GetRequest = TembaRequest & {
   id: string | null
+  isHeadRequest: boolean
 }
 
 export type PostRequest = TembaRequest & {

--- a/src/requestInterceptor/interceptRequest.ts
+++ b/src/requestInterceptor/interceptRequest.ts
@@ -1,4 +1,18 @@
-import type { InterceptedPostRequest, InterceptedPutRequest, InterceptedReturnValue } from './types'
+import type {
+  InterceptedDeleteRequest,
+  InterceptedGetRequest,
+  InterceptedPostRequest,
+  InterceptedPutRequest,
+  InterceptedReturnValue,
+} from './types'
+
+export const interceptGetRequest = (
+  intercept: InterceptedGetRequest,
+  resource: string,
+  id: string | null,
+) => {
+  intercept({ resource, id })
+}
 
 export const interceptPostRequest = (
   intercept: InterceptedPostRequest,
@@ -20,6 +34,14 @@ export const interceptPutRequest = (
 }
 
 export const interceptPatchRequest = interceptPutRequest
+
+export const interceptDeleteRequest = (
+  intercept: InterceptedDeleteRequest,
+  resource: string,
+  id: string | null,
+) => {
+  intercept({ resource, id })
+}
 
 const interceptRequest = (intercepted: InterceptedReturnValue, body: unknown) => {
   if (!intercepted && typeof body === 'object') return body

--- a/src/requestInterceptor/interceptRequest.ts
+++ b/src/requestInterceptor/interceptRequest.ts
@@ -1,12 +1,27 @@
-import type { RequestInterceptorCallback } from './types'
+import type { InterceptedPostRequest, InterceptedPutRequest, InterceptedReturnValue } from './types'
 
-export const interceptRequest = (
-  intercept: RequestInterceptorCallback,
+export const interceptPostRequest = (
+  intercept: InterceptedPostRequest,
   resource: string,
   body: unknown,
 ) => {
   const intercepted = intercept({ resource, body })
+  return interceptRequest(intercepted, body)
+}
 
+export const interceptPutRequest = (
+  intercept: InterceptedPutRequest,
+  resource: string,
+  id: string,
+  body: unknown,
+) => {
+  const intercepted = intercept({ resource, id, body })
+  return interceptRequest(intercepted, body)
+}
+
+export const interceptPatchRequest = interceptPutRequest
+
+const interceptRequest = (intercepted: InterceptedReturnValue, body: unknown) => {
   if (!intercepted && typeof body === 'object') return body
 
   // The request body was replaced by an object

--- a/src/requestInterceptor/types.ts
+++ b/src/requestInterceptor/types.ts
@@ -1,12 +1,24 @@
-type InterceptedRequest = {
+type InterceptedResource = {
   resource: string
+}
+
+type WithBody = InterceptedResource & {
   body: unknown
 }
 
-export type RequestInterceptorCallback = (info: InterceptedRequest) => void | object
+type WithIdAndBody = InterceptedResource & {
+  id: string
+  body: unknown
+}
+
+export type InterceptedReturnValue = void | object
+
+export type InterceptedPostRequest = (request: WithBody) => InterceptedReturnValue
+export type InterceptedPatchRequest = (request: WithIdAndBody) => InterceptedReturnValue
+export type InterceptedPutRequest = (request: WithIdAndBody) => InterceptedReturnValue
 
 export type RequestInterceptor = {
-  post?: RequestInterceptorCallback
-  patch?: RequestInterceptorCallback
-  put?: RequestInterceptorCallback
+  post?: InterceptedPostRequest
+  patch?: InterceptedPatchRequest
+  put?: InterceptedPutRequest
 }

--- a/src/requestInterceptor/types.ts
+++ b/src/requestInterceptor/types.ts
@@ -2,6 +2,10 @@ type InterceptedResource = {
   resource: string
 }
 
+type WithMaybeId = InterceptedResource & {
+  id: string | null
+}
+
 type WithBody = InterceptedResource & {
   body: unknown
 }
@@ -13,12 +17,16 @@ type WithIdAndBody = InterceptedResource & {
 
 export type InterceptedReturnValue = void | object
 
+export type InterceptedGetRequest = (request: WithMaybeId) => InterceptedReturnValue
 export type InterceptedPostRequest = (request: WithBody) => InterceptedReturnValue
 export type InterceptedPatchRequest = (request: WithIdAndBody) => InterceptedReturnValue
 export type InterceptedPutRequest = (request: WithIdAndBody) => InterceptedReturnValue
+export type InterceptedDeleteRequest = (request: WithMaybeId) => InterceptedReturnValue
 
 export type RequestInterceptor = {
+  get?: InterceptedGetRequest
   post?: InterceptedPostRequest
   patch?: InterceptedPatchRequest
   put?: InterceptedPutRequest
+  delete?: InterceptedDeleteRequest
 }

--- a/src/resourceRouter.ts
+++ b/src/resourceRouter.ts
@@ -48,6 +48,7 @@ const convertToGetRequest = (requestInfo: RequestInfo) => {
   return {
     id: requestInfo.id,
     resource: requestInfo.resource,
+    isHeadRequest: requestInfo.method.toUpperCase() === 'HEAD',
   } satisfies GetRequest
 }
 
@@ -103,6 +104,7 @@ export const createResourceRouter = (
       body: req.body,
       host,
       protocol,
+      method: req.method,
     } satisfies RequestInfo
   }
 

--- a/test/integration/requestInterceptor/requestInterceptor-callback-values.test.ts
+++ b/test/integration/requestInterceptor/requestInterceptor-callback-values.test.ts
@@ -1,34 +1,72 @@
-import { test, assert } from 'vitest'
+import { test, expect } from 'vitest'
 import request from 'supertest'
 import type { UserConfig } from '../../../src/config'
 import createServer from '../createServer'
 import { RequestInterceptor } from '../../../src/requestInterceptor/types'
+import { TembaError } from '../../../src'
 
 type MyBody = { name: string }
 
 const requestInterceptor = {
+  get: ({ resource, id }) => {
+    if (resource !== 'get-stuff') throw new TembaError('resource is not get-stuff', 400)
+    if (id !== 'get-id') throw new TembaError('id is not get-id', 400)
+    throw new TembaError('GET is OK', 200)
+  },
   post: ({ resource, body }) => {
-    assert(resource === 'post-stuff')
-    assert((body as MyBody).name === 'post-name')
+    if (resource !== 'post-stuff') throw new TembaError('resource is not post-stuff', 400)
+    if ((body as MyBody).name !== 'post-name')
+      throw new TembaError('body does not have post-name', 400)
+    throw new TembaError('POST is OK', 200)
   },
   put: ({ resource, id, body }) => {
-    assert(resource === 'put-stuff')
-    assert(id === 'put-id')
-    assert((body as MyBody).name === 'put-name')
+    if (resource !== 'put-stuff') throw new TembaError('resource is not put-stuff', 400)
+    if (id !== 'put-id') throw new TembaError('id is not put-id', 400)
+    if ((body as MyBody).name !== 'put-name')
+      throw new TembaError('body does not have put-name', 400)
+    throw new TembaError('PUT is OK', 200)
   },
   patch: ({ resource, id, body }) => {
-    assert(resource === 'patch-stuff')
-    assert(id === 'patch-id')
-    assert((body as MyBody).name === 'patch-name')
+    if (resource !== 'patch-stuff') throw new TembaError('resource is not patch-stuff', 400)
+    if (id !== 'patch-id') throw new TembaError('id is not patch-id', 400)
+    if ((body as MyBody).name !== 'patch-name')
+      throw new TembaError('body does not have patch-name', 400)
+    throw new TembaError('PATCH is OK', 200)
+  },
+  delete: ({ resource, id }) => {
+    if (resource !== 'delete-stuff') throw new TembaError('resource is not delete-stuff', 400)
+    if (id !== 'delete-id') throw new TembaError('id is not delete-id', 400)
+    throw new TembaError('DELETE is OK', 200)
   },
 } satisfies RequestInterceptor
 
 const tembaServer = createServer({ requestInterceptor } satisfies UserConfig)
 
 test('requestInterceptors supply correct values to callback function', async () => {
-  await request(tembaServer).post('/post-stuff').send({ name: 'post-name' })
+  const getResponse = await request(tembaServer).get('/get-stuff/get-id')
+  expect(getResponse.status).toBe(200)
+  expect(getResponse.body).toEqual({ message: 'GET is OK' })
 
-  await request(tembaServer).put('/put-stuff/put-id').send({ name: 'put-name' })
+  // HEAD requests have no specific implementation, so will not go through a requestInterceptor
+  const headResponse = await request(tembaServer).head('/head-stuff')
+  expect(headResponse.status).toBe(200)
+  expect(headResponse.body).toEqual({})
 
-  await request(tembaServer).patch('/patch-stuff/patch-id').send({ name: 'patch-name' })
+  const postResponse = await request(tembaServer).post('/post-stuff').send({ name: 'post-name' })
+  expect(postResponse.status).toBe(200)
+  expect(postResponse.body).toEqual({ message: 'POST is OK' })
+
+  const putResponse = await request(tembaServer).put('/put-stuff/put-id').send({ name: 'put-name' })
+  expect(putResponse.status).toBe(200)
+  expect(putResponse.body).toEqual({ message: 'PUT is OK' })
+
+  const patchResponse = await request(tembaServer)
+    .patch('/patch-stuff/patch-id')
+    .send({ name: 'patch-name' })
+  expect(patchResponse.status).toBe(200)
+  expect(patchResponse.body).toEqual({ message: 'PATCH is OK' })
+
+  const deleteResponse = await request(tembaServer).delete('/delete-stuff/delete-id')
+  expect(deleteResponse.status).toBe(200)
+  expect(deleteResponse.body).toEqual({ message: 'DELETE is OK' })
 })

--- a/test/integration/requestInterceptor/requestInterceptor-callback-values.test.ts
+++ b/test/integration/requestInterceptor/requestInterceptor-callback-values.test.ts
@@ -1,0 +1,34 @@
+import { test, assert } from 'vitest'
+import request from 'supertest'
+import type { UserConfig } from '../../../src/config'
+import createServer from '../createServer'
+import { RequestInterceptor } from '../../../src/requestInterceptor/types'
+
+type MyBody = { name: string }
+
+const requestInterceptor = {
+  post: ({ resource, body }) => {
+    assert(resource === 'post-stuff')
+    assert((body as MyBody).name === 'post-name')
+  },
+  put: ({ resource, id, body }) => {
+    assert(resource === 'put-stuff')
+    assert(id === 'put-id')
+    assert((body as MyBody).name === 'put-name')
+  },
+  patch: ({ resource, id, body }) => {
+    assert(resource === 'patch-stuff')
+    assert(id === 'patch-id')
+    assert((body as MyBody).name === 'patch-name')
+  },
+} satisfies RequestInterceptor
+
+const tembaServer = createServer({ requestInterceptor } satisfies UserConfig)
+
+test('requestInterceptors supply correct values to callback function', async () => {
+  await request(tembaServer).post('/post-stuff').send({ name: 'post-name' })
+
+  await request(tembaServer).put('/put-stuff/put-id').send({ name: 'put-name' })
+
+  await request(tembaServer).patch('/patch-stuff/patch-id').send({ name: 'patch-name' })
+})

--- a/test/unit/config/config.test.ts
+++ b/test/unit/config/config.test.ts
@@ -31,9 +31,13 @@ test('No config returns default config', () => {
   expect(initializedConfig.connectionString).toBe(defaultConfig.connectionString)
   expect(initializedConfig.cacheControl).toBe(defaultConfig.cacheControl)
   expect(initializedConfig.delay).toBe(defaultConfig.delay)
+  expect(initializedConfig.requestInterceptor?.get).toBe(defaultConfig.requestInterceptor?.get)
   expect(initializedConfig.requestInterceptor?.post).toBe(defaultConfig.requestInterceptor?.post)
   expect(initializedConfig.requestInterceptor?.patch).toBe(defaultConfig.requestInterceptor?.patch)
   expect(initializedConfig.requestInterceptor?.put).toBe(defaultConfig.requestInterceptor?.put)
+  expect(initializedConfig.requestInterceptor?.delete).toBe(
+    defaultConfig.requestInterceptor?.delete,
+  )
   expect(initializedConfig.responseBodyInterceptor).toBe(defaultConfig.responseBodyInterceptor)
   expect(initializedConfig.customRouter).toBe(defaultConfig.customRouter)
   expect(initializedConfig.returnNullFields).toBe(defaultConfig.returnNullFields)
@@ -57,6 +61,9 @@ test('Full user config overrides all defaults', () => {
     cacheControl: 'no-cache',
     delay: 1000,
     requestInterceptor: {
+      get: () => {
+        // do nothing
+      },
       post: () => {
         // do nothing
       },
@@ -64,6 +71,9 @@ test('Full user config overrides all defaults', () => {
         // do nothing
       },
       put: () => {
+        // do nothing
+      },
+      delete: () => {
         // do nothing
       },
     },
@@ -97,9 +107,11 @@ test('Full user config overrides all defaults', () => {
   expect(config.connectionString).toBe('mongodb://localhost:27017')
   expect(config.cacheControl).toBe('no-cache')
   expect(config.delay).toBe(1000)
+  expect(config.requestInterceptor!.get).toBeInstanceOf(Function)
   expect(config.requestInterceptor!.post).toBeInstanceOf(Function)
   expect(config.requestInterceptor!.patch).toBeInstanceOf(Function)
   expect(config.requestInterceptor!.put).toBeInstanceOf(Function)
+  expect(config.requestInterceptor!.delete).toBeInstanceOf(Function)
   expect(config.responseBodyInterceptor).toBeInstanceOf(Function)
   expect(config.customRouter).not.toBeNull()
   expect(config.returnNullFields).toBe(false)
@@ -121,9 +133,11 @@ test('Partial user config applies those, but leaves the rest at default', () => 
   expect(config.connectionString).toBe(defaultConfig.connectionString)
   expect(config.cacheControl).toBe(defaultConfig.cacheControl)
   expect(config.delay).toBe(defaultConfig.delay)
+  expect(config.requestInterceptor?.get).toBe(defaultConfig.requestInterceptor?.get)
   expect(config.requestInterceptor?.post).toBe(defaultConfig.requestInterceptor?.post)
   expect(config.requestInterceptor?.patch).toBe(defaultConfig.requestInterceptor?.patch)
   expect(config.requestInterceptor?.put).toBe(defaultConfig.requestInterceptor?.put)
+  expect(config.requestInterceptor?.delete).toBe(defaultConfig.requestInterceptor?.delete)
   expect(config.responseBodyInterceptor).toBe(defaultConfig.responseBodyInterceptor)
   expect(config.customRouter).toBe(defaultConfig.customRouter)
   expect(config.returnNullFields).toBe(defaultConfig.returnNullFields)


### PR DESCRIPTION
Fixes https://github.com/bouwe77/temba/issues/29, so we can now also intercept `GET` and `DELETE` requests.