### PR TITLE
Fix URL parser to ignore query strings

### DIFF
--- a/packages/temba/src/urls/urlParser.ts
+++ b/packages/temba/src/urls/urlParser.ts
@@ -1,5 +1,6 @@
 export const parseUrl = (url: string) => {
-  const urlSegments = url.split('/').filter((i) => i)
+  const path = url.split('?')[0]
+  const urlSegments = path.split('/').filter((i) => i)
 
   const resource = (urlSegments.length > 0 ? urlSegments[0] : null) ?? null
   const id = (urlSegments.length > 1 ? urlSegments[1] : null) ?? null

--- a/packages/temba/test/unit/urls/urlParser.test.ts
+++ b/packages/temba/test/unit/urls/urlParser.test.ts
@@ -11,6 +11,7 @@ test.each([
   ['/stuff/', resourceOnly],
   ['//stuff/', resourceOnly],
   ['/stuff//', resourceOnly],
+  ['stuff?x=1', resourceOnly],
 ])("URL '%s' only has a resource: %o", (url, expected) => {
   const actual = parseUrl(url)
   expect(actual).toEqual(expected)
@@ -24,6 +25,7 @@ test.each([
   ['/stuff//foo/', resourceAndId],
   // When using an API prefix, while not configured, the API prefix becomes the resource, and the resource the id...
   ['/api//movies/', { resource: 'api', id: 'movies' }],
+  ['stuff/foo?bar=baz', resourceAndId],
 ])("URL '%s' has both a resource and id: %o", (url, expected) => {
   const actual = parseUrl(url)
   expect(actual).toEqual(expected)


### PR DESCRIPTION
## Summary
- fix url parsing when query strings are present
- test url parser with query parameters

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f40283a348330a61a1b706e2ef174