### PR TITLE
Fix headover typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You’ll see:
 
 Now you can send any HTTP request to any resource on localhost:8362 — and it just works.
 
-Or headover to the interactive OpenAPI specification of your API in your browser at `/openapi`.
+Or head over to the interactive OpenAPI specification of your API in your browser at `/openapi`.
 
 ## Documentation
 

--- a/docs/docs/documentation.md
+++ b/docs/docs/documentation.md
@@ -68,7 +68,7 @@ You’ll see:
 
 Now you can send any HTTP request to any resource on localhost:8362 — and it just works.
 
-Or headover to the interactive OpenAPI specification of your API in your browser at `/openapi`.
+Or head over to the interactive OpenAPI specification of your API in your browser at `/openapi`.
 
 ### Adding to an existing app
 


### PR DESCRIPTION
## Summary
- replace `headover` with `head over` in main docs

## Testing
- `npx vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f426bc2fc83308b0bbf357c8d5184