### PR TITLE
Fix CRUD test check

### DIFF
--- a/packages/temba/test/integration/crud.test.ts
+++ b/packages/temba/test/integration/crud.test.ts
@@ -128,7 +128,7 @@ describe('CRUD', async () => {
     // Check there are no items anymore.
     const getAllResponse3 = await request(tembaServer).get(resource)
     expect(getAllResponse3.status).toBe(200)
-    expect(getAllResponse2.body.length).toBe(0)
+    expect(getAllResponse3.body.length).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Summary
- fix assertion after delete in CRUD integration test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f42721e748330a3af5b08a21f62de