### PR TITLE
Fix etag module comment

### DIFF
--- a/packages/temba/src/etags/etags.ts
+++ b/packages/temba/src/etags/etags.ts
@@ -1,6 +1,6 @@
 import etagFromExpress, { type StatsLike } from 'etag'
 
-// Temba uses generating etags both for generating etags and for comparing etags.
+// Temba uses the `etag` module both to generate and compare ETags.
 // Express only supports generating them, so to be sure we use the same algorithm for both,
 // we use the etag module for both by wrapping it here.
 // This means we also override the default Express etag function, but that's with the same algorithm.


### PR DESCRIPTION
## Summary
- clarify comment about how etags are generated and compared

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4275e63c8330907ffca0e1e96d88