### PR TITLE
Fix OPTIONS to return 204

### DIFF
--- a/packages/temba/src/index.ts
+++ b/packages/temba/src/index.ts
@@ -17,7 +17,7 @@ const removePendingAndTrailingSlashes = (url?: string) => (url ? url.replace(/^\
 
 const handleOptionsRequest = (res: ServerResponse<IncomingMessage>) =>
   sendResponse(res)({
-    statusCode: 200,
+    statusCode: 204,
   })
 
 const createServer = async (userConfig?: UserConfig) => {

--- a/packages/temba/test/integration/root-url.test.ts
+++ b/packages/temba/test/integration/root-url.test.ts
@@ -60,9 +60,9 @@ describe('Other methods', () => {
     },
   )
 
-  test('OPTIONS on root URL returns 200 OK', async () => {
+  test('OPTIONS on root URL returns 204 No Content', async () => {
     const response = await request(tembaServer).options('/')
-    expect(response.statusCode).toEqual(200)
-    expect(response.body).toBeDefined()
+    expect(response.statusCode).toEqual(204)
+    expect(JSON.stringify(response.body)).toEqual('{}')
   })
 })


### PR DESCRIPTION
## Summary
- return 204 No Content for OPTIONS requests
- update root URL integration test

## Testing
- `npx vitest` *(fails: 403 Forbidden to fetch vitest)*

------
https://chatgpt.com/codex/tasks/task_e_683f44a6a0588330bed95e77229018e6